### PR TITLE
Minor fixes for carbons

### DIFF
--- a/src/mod_message_carbon.erl
+++ b/src/mod_message_carbon.erl
@@ -63,7 +63,9 @@ process_carbon_iq(From, _To, #iq{type = set, sub_el = {xmlelement, "enable", _, 
 	IQ#iq{type = result, sub_el = []};
 process_carbon_iq(From, _To, #iq{type = set, sub_el = {xmlelement, "disable", _, _}} = IQ) ->
 	ok = mnesia:dirty_delete_object(#carbon{jid = {From#jid.luser, From#jid.lserver}, res = From#jid.lresource}),
-	IQ#iq{type = result, sub_el = []}.
+	IQ#iq{type = result, sub_el = []};
+process_carbon_iq(_From, _To, IQ) ->
+        IQ.
 
 filter_packet({From, To, {xmlelement, "message", _, _} = Pkt}) ->
 	case xml:get_tag_attr_s("type", Pkt) of


### PR DESCRIPTION
I've found a problem, some messages didn't have to or from fields, that made it hard for the client to understand where the message came from.

F.e. clientA sends mesage to clientB:

```
<message to="clientB">
</message>
```

Then clientB receives a carbon:

```
<message to="clientB">
</message>
```

And it's hard to determine who sent the message to him.
